### PR TITLE
acknowledgments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,12 +261,7 @@ The membership of OECD_, UN_ and EU_ can be found at the membership organisation
 Acknowledgements
 ----------------
 
-This package was inspired by (and the regular expression are mostly based on) the R-package countrycode_ by Julian_ Hinz and its port to Python (pycountrycode_) by Vincent_ Arel-Bundock.
+This package was inspired by (and the regular expression are mostly based on) the R-package countrycode_ by Vincent Arel-Bundock and his (defunct) port to Python (pycountrycode_).
 
-.. _Julian: http://julianhinz.com/
-.. _countrycode: https://github.com/julianhinz/countrycode
 .. _Vincent: http://arelbundock.com/
-.. _pycountrycode: http://github.com/vincentarelbundock/pycountrycode
-
-
-
+.. _countrycode: https://github.com/vincentarelbundock/countrycode


### PR DESCRIPTION
1. I no longer host the ``pycountrycode`` repository, but am very happy that you picked up on it.
2. Looks like Julian's countrycode repository was in fact an fork of my own R package called ``countrycode``, which has been on CRAN since 2009. I fixed the acknowledgment.
3. I *strongly* recommend you use the updated regexes using the dictionary in master http://github.com/vincentarelbundock/countrycode
4. We are in the process of a complete rebuild of the dictionary, adding country-year functionality for time-varying codes. See here: http://github.com/vincentarelbundock/countryyear