### PR TITLE
Update deprecated pandas API

### DIFF
--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -427,7 +427,7 @@ class CountryConverter():
 
         add_data = [data_loader(df) for df in additional_data]
         self.data = pd.concat([basic_df] + add_data, ignore_index=True,
-                              axis=0)
+                              axis=0, sort=True)
 
         test_for_unique_names(
             self.data,

--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -407,7 +407,7 @@ class CountryConverter():
                 ret = data
                 test_for_unique_names(data)
             else:
-                ret = pd.read_table(data, sep='\t', encoding='utf-8',
+                ret = pd.read_csv(data, sep='\t', encoding='utf-8',
                                     converters={str_col: str
                                                 for str_col in must_be_string})
                 test_for_unique_names(ret, data)

--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -524,7 +524,7 @@ class CountryConverter():
                 for ind_regex, ccregex in enumerate(self.regexes):
                     if ccregex.search(spec_name):
                         result_list.append(
-                            self.data.ix[ind_regex, to].values[0])
+                            self.data.loc[ind_regex, to].values[0])
                     if len(result_list) > 1:
                         logging.warning('More then one regular expression '
                                         'match for {}'.format(spec_name))

--- a/tests/test_country_converter.py
+++ b/tests/test_country_converter.py
@@ -25,8 +25,8 @@ def get_regex_test_data(request):
                                     ['data_name', 'data'])
     return retval(
         request.param,
-        pd.read_table(os.path.join(TESTPATH, request.param),
-                      encoding='utf-8'))
+        pd.read_csv(os.path.join(TESTPATH, request.param),
+                      sep='\t', encoding='utf-8'))
 
 
 def test_name_short():


### PR DESCRIPTION
Update pandas API usage according to deprecation notices.

 - `.ix` is deprecated
 - `.read_table` is deprecated
 - Sorting concatenation as default is deprecated


Example output from deprecation notices:

```
tests/test_country_converter.py::test_obsolete_output
  ...site-packages/pandas/core/indexing.py:1017: DeprecationWarning:
  .ix is deprecated. Please use
  .loc for label based indexing or
  .iloc for positional indexing

  See the documentation here:
  http://pandas.pydata.org/pandas-docs/stable/indexing.html#ix-indexer-is-deprecated
    return getattr(section, self.name)[new_key]

...

tests/test_country_converter.py::test_alternative_names[test_regex_misc.txt]
  .../country_converter/tests/test_country_converter.py:29: FutureWarning: read_table is deprecated, use read_csv instead, passing sep='\t'.
    encoding='utf-8'))

...

tests/test_country_converter.py::test_additional_country_data
  .../country_converter/country_converter/country_converter.py:430: FutureWarning: Sorting because non-concatenation axis is not aligned. A future version
  of pandas will change to not sort by default.

  To accept the future behavior, pass 'sort=False'.

  To retain the current behavior and silence the warning, pass 'sort=True'.
```