### PR TITLE
wrapped spec_name in re.escape()

### DIFF
--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -583,7 +583,7 @@ class CountryConverter:
                     etr[0]
                     for etr in self.data[
                         _match_col.str.contains(
-                            "^" + spec_name + "$", flags=re.IGNORECASE, na=False
+                            "^" + re.escape(spec_name) + "$", flags=re.IGNORECASE, na=False
                         )
                     ][to].values
                 ]


### PR DESCRIPTION
Allows for countries to have names with regular expression characters, such as parenthesis or dots.
Specifically fixes bug when trying to use `coco.convert("Hong Kong (China)", from="IEA", to="ISO3")`.