### PR TITLE
IEA update and bug fix

### DIFF
--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -855,7 +855,7 @@ def _parse_arg(valid_classifications):
 
 def cli_output(conv_names, sep):
     """Helper function for printing to the console"""
-    pd.set_option("max_rows", len(str(conv_names)))
+    pd.options.display.max_rows = len(str(conv_names))
     if type(conv_names) is pd.DataFrame:
         if len(conv_names.columns) == 1:
             conv_names = conv_names.iloc[:, 0].tolist()

--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -583,7 +583,7 @@ class CountryConverter:
                     etr[0]
                     for etr in self.data[
                         _match_col.str.contains(
-                            "^" + spec_name + "$", flags=re.IGNORECASE, na=False
+                            "^" + re.escape(spec_name) + "$", flags=re.IGNORECASE, na=False
                         )
                     ][to].values
                 ]

--- a/country_converter/country_converter.py
+++ b/country_converter/country_converter.py
@@ -583,7 +583,9 @@ class CountryConverter:
                     etr[0]
                     for etr in self.data[
                         _match_col.str.contains(
-                            "^" + re.escape(spec_name) + "$", flags=re.IGNORECASE, na=False
+                            "^" + re.escape(spec_name) + "$",
+                            flags=re.IGNORECASE,
+                            na=False,
                         )
                     ][to].values
                 ]


### PR DESCRIPTION
Wrapped spec_name in re.escape(). Allows for countries to have names with regular expression characters, such as parenthesis or dots. Specifically fixes bug when trying to use coco.convert("Hong Kong (China)", from="IEA", to="ISO3").
Also changed pd.set_option("max_rows", len(str(conv_names))) to "pd.options.display.max_rows = len(str(conv_names))" as the former returned OptionError: "Pattern matched multiple keys".