### PR TITLE
Update name for TR to 'Türkiye'

### DIFF
--- a/country_converter/country_data.tsv
+++ b/country_converter/country_data.tsv
@@ -232,7 +232,7 @@ Tokelau	Tokelau	tokelau	TK	TKL	772	772	218	413	Oceania	Polynesia	WW	WA	WA	WWW	WW
 Tonga	Kingdom of Tonga	tonga	TO	TON	776	776	219	29	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TON	PAS	Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	870
 Trinidad and Tobago	Republic of Trinidad and Tobago	trinidad|tobago	TT	TTO	780	780	220	119	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TTO	LAC	Central America	LAM												1962	1962		RoW							Trinidad and Tobago	
 Tunisia	Republic of Tunisia	tunisia	TN	TUN	788	788	222	154	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TUN	MEA	Northern Africa	MEA												1956	1956		RoW							Tunisia	139
-Turkey	Republic of Türkiye	t[ü|u]rk[i|e]y	TR	TUR	792	792	223	155	Asia	Western Asia	TR	TR	TR	TUR	TUR	TUR	TUR	TUR	WEU	Turkey	NEU	1961											1945	1945		BX						G20	Turkey	55
+Türkiye	Republic of Türkiye	t[ü|u]rk[i|e]y	TR	TUR	792	792	223	155	Asia	Western Asia	TR	TR	TR	TUR	TUR	TUR	TUR	TUR	WEU	Turkey	NEU	1961											1945	1945		BX						G20	Türkiye	55
 Turkmenistan	Turkmenistan	turk-?men	TM	TKM	795	795	213	40	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TKM	FSU	Central Asia	REF												1992	1992		RoW							Turkmenistan	616
 Turks and Caicos Islands	Turks and Caicos Islands	turks	TC	TCA	796	796	224		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TCA		Central America	LAM															RoW							Other non-OECD Americas	
 Tuvalu	Tuvalu	tuvalu	TV	TUV	798	798	227	416	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TUV		Oceania	OAS												2000	2000		RoW							Other non-OECD Asia	872

--- a/tests/test_regex_misc.txt
+++ b/tests/test_regex_misc.txt
@@ -113,8 +113,8 @@ Tanzania	"Tanzania, united republic of"
 Tanzania	United Rep. of Tanzania
 Tanzania	United Republic of Tanzania
 Tanzania	Tanzania (United Republic of)
-Turkey	Türkiye
-Turkey	Republic of Turkey
+Türkiye	Turkey
+Türkiye	Republic of Turkey
 Timor-Leste	Democratic Republic of Timor-Leste
 Timor-Leste	East Timor
 Turks and Caicos Islands	Turks and caicos islands


### PR DESCRIPTION
Update the `country_converter/country_data.tsv` for the UN and IEA names, but not IMAGE (as they have not done a new release since 2021-12, and this name changed in 2022-06).

Update `tests/test_regex_misc.txt` to use the new names, though it wasn't clear to me what the two fields in the file were. I updated them so that the tests in `format_and_test.sh` passed.

Fixes #121