### PR TITLE
country_converter/country_data.tsv: fix UN M.49 region

### DIFF
--- a/country_converter/country_data.tsv
+++ b/country_converter/country_data.tsv
@@ -34,12 +34,12 @@ Brazil	Federative Republic of Brazil	brazil	BR	BRA	76	76	21	135	America	South Am
 British Antarctic Territories	British Antarctic Territories	br.*antarctic.?territ.*	B1	BA1					Antarctica		WW	WA	WA	WWW	WWA	WWA	RoW																		1979	RoW								
 British Indian Ocean Territory	British Indian Ocean Territory	br.*indian.?ocean	IO	IOT	86	86	24		Africa	Eastern Africa	WW	WA	WA	WWW	WWA	WWA	RoW		AFR		OAS															RoW							Other non-OECD Asia	
 British Virgin Islands	British Virgin Islands	^(?=.*\bu\.?\s?k).*virgin|^(?=.*br.*).*virgin|^(?=.*kingdom).*virgin|BVI	VG	VGB	92	92	239		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VGB		Central America	LAM															RoW							Other non-OECD Americas	
-Brunei Darussalam	"Nation of Brunei, Abode of Peace"	brunei	BN	BRN	96	96	26	66	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BRN	PAS	Southeastern Asia	OAS												1984	1984		RoW		APEC					Brunei Darussalam	
+Brunei Darussalam	"Nation of Brunei, Abode of Peace"	brunei	BN	BRN	96	96	26	66	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BRN	PAS	Southeastern Asia	OAS												1984	1984		RoW		APEC					Brunei Darussalam	
 Bulgaria	Republic of Bulgaria	bulgaria	BG	BGR	100	100	27	45	Europe	Eastern Europe	BG	BG	BG	BGR	BGR	BGR	BGR	BGR	EEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007				EEA			1955	1955		EU						G20	Bulgaria	72
 Burkina Faso	Burkina Faso	burkina|\bfaso|upper.?volta	BF	BFA	854	854	233	201	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BFA	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	287
 Burundi	Republic of Burundi	burundi	BI	BDI	108	108	29	175	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BDI	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	228
 Cabo Verde	Republic of Cabo Verde	(cabo|cape) *verde	CV	CPV	132	132	35	203	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CPV	AFR	Western Africa	SSA												1975	1975		RoW							Other Africa	230
-Cambodia	Kingdom of Cambodia	cambodia|kampuchea|khmer|^p\.?r\.?k\.?$	KH	KHM	116	116	115	10	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KHM	CPA	Southeastern Asia	OAS												1955	1955		RoW							Cambodia	728
+Cambodia	Kingdom of Cambodia	cambodia|kampuchea|khmer|^p\.?r\.?k\.?$	KH	KHM	116	116	115	10	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KHM	CPA	Southeastern Asia	OAS												1955	1955		RoW							Cambodia	728
 Cameroon	Republic of Cameroon	cameroon	CM	CMR	120	120	32	202	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CMR	AFR	Western Africa	SSA												1960	1960		RoW							Cameroon	229
 Canada	Canada	canada	CA	CAN	124	124	33	101	America	Northern America	CA	CA	CA	CAN	CAN	CAN	CAN	CAN	NAM	Canada	CAZ	1961											1945	1945		HI		APEC			G7	G20	Canada	301
 Cayman Islands	Cayman Islands	cayman	KY	CYM	136	136	36		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	CYM		Central America	LAM															RoW							Other non-OECD Americas	
@@ -105,7 +105,7 @@ Hong Kong	Hong Kong SAR	.*hong.*kong|hksar	HK	HKG	344	344	96		Asia	Eastern Asia	
 Hungary	Republic of Hungary	hungary	HU	HUN	348	348	97	48	Europe	Eastern Europe	HU	HU	HU	HUN	HUN	HUN	HUN	HUN	EEU	Central Europe	EUR	1996	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1955	1955		EU						G20	Hungary	75
 Iceland	Republic of Iceland	iceland	IS	ISL	352	352	99	83	Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	ISL	WEU	Western Europe	NEU	1961								EEA	Schengen		1946	1946		RoW							Iceland	20
 India	Republic of India	^(?!\D*(?:bassas))\D*india(?!.*ocea)(?!na)	IN	IND	356	356	100	163	Asia	Southern Asia	IN	IN	IN	IND	IND	IND	IND	IND	SAS	India	IND												1945	1945		BX	BRIC		BASIC			G20	India	645
-Indonesia	Republic of Indonesia	indonesia	ID	IDN	360	360	101	11	Asia	South-Eastern Asia	ID	ID	ID	IDN	IDN	IDN	IDN	IDN	PAS	Indonesia region	OAS												1950	1950		BX		APEC				G20	Indonesia	738
+Indonesia	Republic of Indonesia	indonesia	ID	IDN	360	360	101	11	Asia	South-eastern Asia	ID	ID	ID	IDN	IDN	IDN	IDN	IDN	PAS	Indonesia region	OAS												1950	1950		BX		APEC				G20	Indonesia	738
 Iran	Islamic Republic of Iran	\biran|persia	IR	IRN	364	364	102	142	Asia	Southern Asia	WW	WM	WM	WWW	WWM	WWM	RoW	IRN	MEA	Middle East	MEA												1945	1945		RoW							Islamic Republic of Iran	540
 Iraq	Republic of Iraq	\biraq|mesopotamia	IQ	IRQ	368	368	103	143	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	IRQ	MEA	Middle East	MEA												1945	1945		RoW							Iraq	543
 Ireland	Ireland	^(?!.*north.*).*ireland	IE	IRL	372	372	104	84	Europe	Northern Europe	IE	IE	IE	IRL	IRL	IRL	IRL	IRL	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA		1999	1955	1955		EU						G20	Ireland	21
@@ -122,7 +122,7 @@ Kiribati	Republic of Kiribati	kiribati	KI	KIR	296	296	83	23	Oceania	Micronesia	W
 Kosovo	Republic of Kosovo	kosovo	XK	XKX					Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	KSV																		RoW							Kosovo	57
 Kuwait	State of Kuwait	kuwait	KW	KWT	414	414	118	145	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	KWT	MEA	Middle East	MEA												1963	1963		RoW							Kuwait	552
 Kyrgyz Republic	Kyrgyz Republic	kyrgyz|kirghiz	KG	KGZ	417	417	113	37	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KGZ	FSU	Central Asia	REF												1992	1992		RoW							Kyrgyzstan	614
-Laos	Lao People's Democratic Republic	\blaos?\b	LA	LAO	418	418	120	12	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	LAO	CPA	Southeastern Asia	OAS												1955	1955		RoW							Lao People's Democratic Republic	745
+Laos	Lao People's Democratic Republic	\blaos?\b	LA	LAO	418	418	120	12	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	LAO	CPA	Southeastern Asia	OAS												1955	1955		RoW							Lao People's Democratic Republic	745
 Latvia	Republic of Latvia	latvia	LV	LVA	428	428	119	59	Europe	Northern Europe	LV	LV	LV	LVA	LVA	LVA	LVA	LVA	EEU	Central Europe	EUR	2016	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2014	1991	1991		EU						G20	Latvia	83
 Lebanon	Lebanese Republic	lebanon|lebanese	LB	LBN	422	422	121	146	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	LBN	MEA	Middle East	MEA												1945	1945		RoW							Lebanon	555
 Lesotho	Kingdom of Lesotho	lesotho|basuto	LS	LSO	426	426	122	194	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	LSO	AFR	Rest of Southern Africa	SSA												1966	1966		RoW							Other Africa	249
@@ -135,7 +135,7 @@ Macau	Macau SAR	.*maca(o|u)	MO	MAC	446	446	128		Asia	Eastern Asia	WW	WA	WA	WWW	W
 North Macedonia	Republic of North Macedonia	macedonia|^f\.?y\.?r\.?o\.?m\.?$	MK	MKD	807	807	154	49	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MKD	EEU	Central Europe	NEU												1993	1993		RoW							Republic of North Macedonia	66
 Madagascar	Republic of Madagascar	madagascar|malagasy	MG	MDG	450	450	129	181	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MDG	AFR	Eastern Africa	SSA												1960	1960		RoW							Other Africa	252
 Malawi	Republic of Malawi	malawi|nyasa	MW	MWI	454	454	130	182	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MWI	AFR	Rest of Southern Africa	SSA												1964	1964		RoW							Other Africa	253
-Malaysia	Malaysia	malaysia	MY	MYS	458	458	131	13	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MYS	PAS	Southeastern Asia	OAS												1957	1957		RoW		APEC					Malaysia	751
+Malaysia	Malaysia	malaysia	MY	MYS	458	458	131	13	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MYS	PAS	Southeastern Asia	OAS												1957	1957		RoW		APEC					Malaysia	751
 Maldives	Republic of Maldives	maldive	MV	MDV	462	462	132	14	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MDV	SAS	Rest of South Asia	OAS												1965	1965		RoW							Other non-OECD Asia	655
 Mali	Republic of Mali	\bmali\b	ML	MLI	466	466	133	211	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MLI	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	255
 Malta	Republic of Malta	\bmalta	MT	MLT	470	470	134	88	Europe	Southern Europe	MT	MT	MT	MLT	MLT	MLT	MLT	MLT	WEU	Western Europe	EUR		EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2008	1964	1964		EU						G20	Malta	45
@@ -177,7 +177,7 @@ Panama	Republic of Panama	panama	PA	PAN	591	591	166	132	America	Central America	
 Papua New Guinea	Independent State of Papua New Guinea	\bp.*\bn.*\bguin.*|^p\.?n\.?g\.?$|new.?guinea	PG	PNG	598	598	168	26	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	PNG	PAS	Indonesia region	OAS												1975	1975		RoW		APEC					Other non-OECD Asia	862
 Paraguay	Republic of Paraguay	paraguay	PY	PRY	600	600	169	136	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	PRY	LAC	Rest of South America	LAM												1945	1945		RoW							Paraguay	451
 Peru	Republic of Peru	peru	PE	PER	604	604	170	123	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	PER	LAC	Rest of South America	LAM												1945	1945		RoW		APEC					Peru	454
-Philippines	Republic of the Philippines	philippines	PH	PHL	608	608	171	16	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PHL	PAS	Southeastern Asia	OAS												1945	1945		RoW		APEC					Philippines	755
+Philippines	Republic of the Philippines	philippines	PH	PHL	608	608	171	16	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PHL	PAS	Southeastern Asia	OAS												1945	1945		RoW		APEC					Philippines	755
 Pitcairn	Pitcairn	pitcairn	PN	PCN	612	612	172		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	PCN		Oceania	OAS															RoW							Other non-OECD Asia	
 Poland	Republic of Poland	poland	PL	POL	616	616	173	51	Europe	Eastern Europe	PL	PL	PL	POL	POL	POL	POL	POL	EEU	Central Europe	EUR	1996	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1945	1945		EU						G20	Poland	76
 Portugal	Portuguese Republic	portugal|portuguese	PT	PRT	620	620	174	91	Europe	Southern Europe	PT	PT	PT	PRT	PRT	PRT	PRT	PRT	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU						G20	Portugal	9
@@ -196,7 +196,7 @@ Senegal	Republic of Senegal	senegal	SN	SEN	686	686	195	216	Africa	Western Africa
 Serbia	Republic of Serbia	^(?!.*monte).*serbia.*	RS	SRB	688	688	272	53	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SRB		Central Europe	NEU												2000	2000		RoW							Serbia	63
 Seychelles	Republic of Seychelles	seychell	SC	SYC	690	690	196	186	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SYC	AFR	Eastern Africa	SSA												1976	1976		RoW							Other Africa	
 Sierra Leone	Republic of Sierra Leone	sierra	SL	SLE	694	694	197	217	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SLE	AFR	Western Africa	SSA												1961	1961		RoW							Other Africa	272
-Singapore	Republic of Singapore	singapore	SG	SGP	702	702	200	69	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	SGP	PAS	Southeastern Asia	OAS												1965	1965		RoW		APEC					Singapore	
+Singapore	Republic of Singapore	singapore	SG	SGP	702	702	200	69	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	SGP	PAS	Southeastern Asia	OAS												1965	1965		RoW		APEC					Singapore	
 Sint Maarten	Sint Maarten (Dutch part)	^(?!.*martin)(?!.*saba).*maarten|dutch.*martin|martin.*dutch	SX	SXM	534	534	280		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Other non-OECD Americas	
 Slovakia	Slovak Republic	^(?!.*cze).*slovak	SK	SVK	703	703	199	54	Europe	Eastern Europe	SK	SK	SK	SVK	SVK	SVK	SVK	SVK	EEU	Central Europe	EUR	2000	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2009	1993	1993		EU						G20	Slovak Republic	69
 Slovenia	Republic of Slovenia	slovenia	SI	SVN	705	705	198	55	Europe	Southern Europe	SI	SI	SI	SVN	SVN	SVN	SVN	SVN	EEU	Central Europe	EUR	2010	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2007	1992	1992		EU						G20	Slovenia	61
@@ -225,8 +225,8 @@ Taiwan	Republic of China	.*taiwan|.*taipei|.*formosa|^(?!.*\bdem)(?!.*\bpe)(?!.*
 Tajikistan	Republic of Tajikistan	tajik	TJ	TJK	762	762	208	39	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TJK	FSU	Central Asia	REF												1992	1992		RoW				CIS			Tajikistan	615
 Tanganjika	Republic of Tanganyika	tanganjika|tanganyika		EAT					Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW																		1964	RoW							Other Africa	
 Tanzania	United Republic of Tanzania	tanzania(?!: zan.*)	TZ	TZA	834	834	215	189	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TZA	AFR	Rest of Southern Africa	SSA												1961	1961		RoW							United Republic of Tanzania	282
-Thailand	Kingdom of Thailand	thailand|\bsiam	TH	THA	764	764	216	18	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	THA	PAS	Southeastern Asia	OAS												1946	1946		RoW		APEC					Thailand	764
-Timor-Leste	Democratic Republic of Timor-Leste	^(?=.*leste).*timor|^(?=.*east).*timor	TL	TLS	626	626	176	19	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TLS		Indonesia region	OAS												2002	2002		RoW							Other non-OECD Asia	765
+Thailand	Kingdom of Thailand	thailand|\bsiam	TH	THA	764	764	216	18	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	THA	PAS	Southeastern Asia	OAS												1946	1946		RoW		APEC					Thailand	764
+Timor-Leste	Democratic Republic of Timor-Leste	^(?=.*leste).*timor|^(?=.*east).*timor	TL	TLS	626	626	176	19	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TLS		Indonesia region	OAS												2002	2002		RoW							Other non-OECD Asia	765
 Togo	Togolese Republic	togo	TG	TGO	768	768	217	218	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TGO	AFR	Western Africa	SSA												1960	1960		RoW							Togo	283
 Tokelau	Tokelau	tokelau	TK	TKL	772	772	218	413	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TKL		Oceania	OAS															RoW							Other non-OECD Asia	868
 Tonga	Kingdom of Tonga	tonga	TO	TON	776	776	219	29	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TON	PAS	Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	870
@@ -248,7 +248,7 @@ Uzbekistan	Republic of Uzbekistan	uzbek	UZ	UZB	860	860	235	41	Asia	Central Asia	
 Vanuatu	Republic of Vanuatu	vanuatu|new.?hebrides	VU	VUT	548	548	155	30	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	VUT	PAS	Oceania	OAS												1981	1981		RoW							Other non-OECD Asia	854
 Vatican	Vatican City State	holy.?see|vatican|papal.?st	VA	VAT	336	336	94		Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	VAT		Western Europe	NEU															RoW								
 Venezuela	Bolivarian Republic of Venezuela	venezuela	VE	VEN	862	862	236	133	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	VEN	LAC	Rest of South America	LAM												1945	1945		RoW							Bolivarian Republic of Venezuela	463
-Vietnam	Socialist Republic of Vietnam	"^((?!n|s|.*republic)|(?=.*socialist)).*viet.?nam(?! *,? *n| *,? *s)"	VN	VNM	704	704	237	20	Asia	South-Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	VNM	CPA	Southeastern Asia	OAS												1977	1977		RoW		APEC					Viet Nam	769
+Vietnam	Socialist Republic of Vietnam	"^((?!n|s|.*republic)|(?=.*socialist)).*viet.?nam(?! *,? *n| *,? *s)"	VN	VNM	704	704	237	20	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	VNM	CPA	Southeastern Asia	OAS												1977	1977		RoW		APEC					Viet Nam	769
 Wallis and Futuna Islands	Wallis and Futuna Islands	futuna|wallis	WF	WLF	876	876	243		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	WLF		Oceania	OAS															RoW							Other non-OECD Asia	876
 Western Sahara	Western Sahara	\bw.*sahara	EH	ESH	732	732	205	199	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ESH		Northern Africa	MEA															RoW							Other Africa	
 Yemen	Republic of Yemen	yemen	YE	YEM	887	887	249	157	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	YEM	MEA	Middle East	MEA												1947	1947		RoW							Yemen	580


### PR DESCRIPTION
According to UN M.49 the region is "South-eastern Asia" with the word "eastern" in lower case. You can see this on the website as well as the CSV data export.

See: https://unstats.un.org/unsd/methodology/m49/#geo-regions
See: https://unstats.un.org/unsd/methodology/m49/overview/

Fixes #115