### PR TITLE
Add missing MESSAGE R11 regions

### DIFF
--- a/country_converter/country_data.tsv
+++ b/country_converter/country_data.tsv
@@ -6,12 +6,12 @@ Algeria	People's Democratic Republic of Algeria	algeria	DZ	DZA	12	12	4	139	Afric
 American Samoa	American Samoa	^(?=.*americ).*samoa	AS	ASM	16	16	5	298	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	ASM	PAS	Oceania	OAS															RoW							Other non-OECD Asia	880	as	
 Andorra	Principality of Andorra	andorra	AD	AND	20	20	6	74	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	AND	WEU	Western Europe	NEU												1993	1993		RoW									ad	232
 Angola	Republic of Angola	angola	AO	AGO	24	24	7	168	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	AGO	AFR	Rest of Southern Africa	SSA												1976	1976		RoW							Angola	225	ao	540
-Anguilla	Anguilla	anguill?a	AI	AIA	660	660	258		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	AIA		Central America	LAM															RoW							Other non-OECD Americas		ai	
+Anguilla	Anguilla	anguill?a	AI	AIA	660	660	258		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	AIA	LAC	Central America	LAM															RoW							Other non-OECD Americas		ai	
 Antarctica	Antarctica	antarctica	AQ	ATA	10	10	30		Antarctica	Antarctica	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia		aq	
 Antigua and Barbuda	Antigua and Barbuda	antigua	AG	ATG	28	28	8	105	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	ATG	LAC		LAM												1981	1981		RoW							Other non-OECD Americas	377	ag	58
 Argentina	Argentine Republic	argentin	AR	ARG	32	32	9	97	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	ARG	LAC	Rest of South America	LAM												1945	1945		RoW						G20	Argentina	425	ar	160
 Armenia	Republic of Armenia	armenia	AM	ARM	51	51	1	33	Asia	Western Asia	WW	WA	WA	WWW	WWA	WWA	RoW	ARM	FSU	Russia region	REF												1992	1992		RoW				CIS			Armenia	610	am	371
-Aruba	Aruba	^(?!.*bonaire).*\baruba	AW	ABW	533	533	22		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	ABW		Central America	LAM															RoW							Other non-OECD Americas		aw	
+Aruba	Aruba	^(?!.*bonaire).*\baruba	AW	ABW	533	533	22		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	ABW	LAC	Central America	LAM															RoW							Other non-OECD Americas		aw	
 Australia	Commonwealth of Australia	australia	AU	AUS	36	36	10	71	Oceania	Australia and New Zealand	AU	AU	AU	AUS	AUS	AUS	AUS	AUS	PAO	Oceania	CAZ	1971											1945	1945		HI		APEC				G20	Australia	801	au	900
 Austria	Republic of Austria	austria	AT	AUT	40	40	11	75	Europe	Western Europe	AT	AT	AT	AUT	AUT	AUT	AUT	AUT	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen	1999	1955	1955		EU						G20	Austria	1	at	305
 Azerbaijan	Republic of Azerbaijan	azerbaijan	AZ	AZE	31	31	52	34	Asia	Western Asia	WW	WA	WA	WWW	WWA	WWA	RoW	AZE	FSU	Russia region	REF												1992	1992		RoW				CIS			Azerbaijan	611	az	373
@@ -26,14 +26,14 @@ Benin	Republic of Benin	benin|dahome	BJ	BEN	204	204	53	200	Africa	Western Africa
 Bermuda	Bermuda	bermuda	BM	BMU	60	60	17	305	America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	BMU	LAC	Central America	LAM															RoW							Other non-OECD Americas		bm	
 Bhutan	Kingdom of Bhutan	bhutan	BT	BTN	64	64	18	162	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BTN	SAS	Rest of South Asia	OAS												1971	1971		RoW							Other non-OECD Asia	630	bt	760
 Bolivia	Plurinational State of Bolivia	bolivia	BO	BOL	68	68	19	121	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	BOL	LAC	Rest of South America	LAM												1945	1945		RoW							Plurinational State of Bolivia	428	bo	145
-Bonaire, Saint Eustatius and Saba	Bonaire, Saint Eustatius and Saba	^(?=.*bonaire).*eustatius|^(?=.*carib).*netherlands|\bbes.?islands	BQ	BES	535	535	278		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Other non-OECD Americas		bq	
+Bonaire, Saint Eustatius and Saba	Bonaire, Saint Eustatius and Saba	^(?=.*bonaire).*eustatius|^(?=.*carib).*netherlands|\bbes.?islands	BQ	BES	535	535	278		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW		LAC		LAM															RoW							Other non-OECD Americas		bq	
 Bosnia and Herzegovina	Bosnia and Herzegovina	herzegovina|bosnia	BA	BIH	70	70	80	44	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	BIH	EEU	Central Europe	NEU												1992	1992		RoW							Bosnia and Herzegovina	64	ba	346
 Botswana	Republic of Botswana	botswana|bechuana	BW	BWA	72	72	20	193	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BWA	AFR	Rest of Southern Africa	SSA												1966	1966		RoW							Botswana	227	bw	571
 Bouvet Island	Bouvet Island	bouvet	BV	BVT	74	74	31		Antarctica	South America	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia			
 Brazil	Federative Republic of Brazil	brazil	BR	BRA	76	76	21	135	America	South America	BR	BR	BR	BRA	BRA	BRA	BRA	BRA	LAC	Brazil	LAM												1945	1945		BX	BRIC		BASIC			G20	Brazil	431	br	140
 British Antarctic Territories	British Antarctic Territories	br.*antarctic.?territ.*	B1	BA1					Antarctica		WW	WA	WA	WWW	WWA	WWA	RoW																		1979	RoW										
 British Indian Ocean Territory	British Indian Ocean Territory	br.*indian.?ocean	IO	IOT	86	86	24		Africa	Eastern Africa	WW	WA	WA	WWW	WWA	WWA	RoW		AFR		OAS															RoW							Other non-OECD Asia		io	
-British Virgin Islands	British Virgin Islands	^(?=.*\bu\.?\s?k).*virgin|^(?=.*br.*).*virgin|^(?=.*kingdom).*virgin|BVI	VG	VGB	92	92	239		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VGB		Central America	LAM															RoW							Other non-OECD Americas		vg	
+British Virgin Islands	British Virgin Islands	^(?=.*\bu\.?\s?k).*virgin|^(?=.*br.*).*virgin|^(?=.*kingdom).*virgin|BVI	VG	VGB	92	92	239		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VGB	LAC	Central America	LAM															RoW							Other non-OECD Americas		vg	
 Brunei Darussalam	Nation of Brunei, Abode of Peace	brunei	BN	BRN	96	96	26	66	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	BRN	PAS	Southeastern Asia	OAS												1984	1984		RoW		APEC					Brunei Darussalam		bn	835
 Bulgaria	Republic of Bulgaria	bulgaria	BG	BGR	100	100	27	45	Europe	Eastern Europe	BG	BG	BG	BGR	BGR	BGR	BGR	BGR	EEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007				EEA			1955	1955		EU						G20	Bulgaria	72	bg	355
 Burkina Faso	Burkina Faso	burkina|\bfaso|upper.?volta	BF	BFA	854	854	233	201	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	BFA	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	287	bf	439
@@ -42,23 +42,23 @@ Cabo Verde	Republic of Cabo Verde	(cabo|cape) *verde	CV	CPV	132	132	35	203	Afric
 Cambodia	Kingdom of Cambodia	cambodia|kampuchea|khmer|^p\.?r\.?k\.?$	KH	KHM	116	116	115	10	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	KHM	CPA	Southeastern Asia	OAS												1955	1955		RoW							Cambodia	728	kh	811
 Cameroon	Republic of Cameroon	cameroon	CM	CMR	120	120	32	202	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CMR	AFR	Western Africa	SSA												1960	1960		RoW							Cameroon	229	cm	471
 Canada	Canada	canada	CA	CAN	124	124	33	101	America	Northern America	CA	CA	CA	CAN	CAN	CAN	CAN	CAN	NAM	Canada	CAZ	1961											1945	1945		HI		APEC			G7	G20	Canada	301	ca	20
-Cayman Islands	Cayman Islands	cayman	KY	CYM	136	136	36		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	CYM		Central America	LAM															RoW							Other non-OECD Americas		ky	
+Cayman Islands	Cayman Islands	cayman	KY	CYM	136	136	36		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	CYM	LAC	Central America	LAM															RoW							Other non-OECD Americas		ky	
 Central African Republic	Central African Republic	central.?african.?rep.*	CF	CAF	140	140	37	169	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CAF	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	231	cf	482
 Chad	Republic of Chad	\bchad	TD	TCD	148	148	39	204	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TCD	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	232	td	483
 Channel Islands	Channel Islands	channel.?island.*		CHI	830	830	259		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW		WEU																2006	RoW										
 Chile	Republic of Chile	\bchile	CL	CHL	152	152	40	98	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	CHL	LAC	Rest of South America	LAM	2010											1945	1945		RoW		APEC					Chile		cl	155
 China	People's Republic of China	^(?!repub)(?!taiwan)(?!hong.*kong)(?!macao).*china(?!.*hong.*kong)(?!.*macao)|^PRC$	CN	CHN	156	156	351	6	Asia	Eastern Asia	CN	CN	CN	CHN	CHN	CHN	CHN	CHN	CPA	China region	CHA												1945	1945		BX	BRIC	APEC	BASIC			G20	People's Republic of China	730	cn	710
-Christmas Island	Christmas Island	christmas	CX	CXR	162	162	42		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW				OAS															RoW							Other non-OECD Asia		cx	
-Cocos (Keeling) Islands	Territory of the Cocos (Keeling) Islands	\bcocos|keeling	CC	CCK	166	166	43		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW				OAS															RoW							Other non-OECD Asia		cc	
+Christmas Island	Christmas Island	christmas	CX	CXR	162	162	42		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW		PAS		OAS															RoW							Other non-OECD Asia		cx	
+Cocos (Keeling) Islands	Territory of the Cocos (Keeling) Islands	\bcocos|keeling	CC	CCK	166	166	43		Asia	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW		PAS		OAS															RoW							Other non-OECD Asia		cc	
 Colombia	Republic of Colombia	colombia	CO	COL	170	170	44	125	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	COL	LAC	Rest of South America	LAM	2020											1945	1945		RoW							Colombia	437	co	100
 Comoros	Union of the Comoros	comoro	KM	COM	174	174	45	176	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	COM	AFR	Eastern Africa	SSA												1975	1975		RoW							Other Africa	233	km	581
 Congo Republic	Republic of the Congo	^(?!.*\bdem)(?!.*\bdr)(?!.*kinshasa)(?!.*zaire)(?!.*belg)(?!.*l\w{1,2}opoldville)(?!.*free)(^rep.*).*\bcongo.*(?!.*\bdem)(?!.*\bdr).*|\bwest.*congo|^congo[,;\s]*(?!.*dem)rep.*?$|^congo$|\bcongo.*brazza.*	CG	COG	178	178	46	170	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	COG	AFR	Western Africa	SSA												1960	1960		RoW							Republic of the Congo	234	cg	484
-Cook Islands	Cook Islands	\bcook	CK	COK	184	184	47	320	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	COK		Oceania	OAS															RoW							Other non-OECD Asia		ck	
+Cook Islands	Cook Islands	\bcook	CK	COK	184	184	47	320	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	COK	PAS	Oceania	OAS															RoW							Other non-OECD Asia		ck	
 Costa Rica	Republic of Costa Rica	costa.?rica	CR	CRI	188	188	48	126	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	CRI	LAC	Central America	LAM	2021											1945	1945		RoW							Costa Rica	336	cr	94
 Cote d'Ivoire	Republic of Côte d'Ivoire	.*(ivoire|ivory)	CI	CIV	384	384	107	205	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	CIV	AFR	Western Africa	SSA												1960	1960		RoW							Côte d'Ivoire	247	ci	437
 Croatia	Republic of Croatia	croatia|hrvatska	HR	HRV	191	191	98	46	Europe	Southern Europe	WW	WE	HR	WWW	WWE	HRV	RoW	HRV	EEU	Central Europe	EUR		EU	EU28	EU27					EEA		2023	1992	1992		RoW						G20	Croatia	62	hr	344
 Cuba	Republic of Cuba	\bcuba	CU	CUB	192	192	49	109	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	CUB	LAC		LAM												1945	1945		RoW							Cuba	338	cu	40
-Curacao	Country of Curaçao	\bcura(c|ç)ao	CW	CUW	531	531	279		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Curaçao/Netherlands Antilles		cw	
+Curacao	Country of Curaçao	\bcura(c|ç)ao	CW	CUW	531	531	279		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW		LAC		LAM															RoW							Curaçao/Netherlands Antilles		cw	
 Cyprus	Republic of Cyprus	cyprus	CY	CYP	196	196	50	77	Asia	Western Asia	CY	CY	CY	CYP	CYP	CYP	CYP	CYP	WEU	Central Europe	EUR		EU	EU28	EU27	EU27_2007	EU25			EEA		2008	1960	1960		EU						G20	Cyprus	30	cy	352
 Czech Republic	Czech Republic	^(?=.*rep).*czech.*|czechia|bohemia|.*czech.*	CZ	CZE	203	203	167	47	Europe	Eastern Europe	CZ	CZ	CZ	CZE	CZE	CZE	CZE	CZE	EEU	Central Europe	EUR	1995	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1993	1993		EU						G20	Czech Republic	68	cz	315
 Denmark	Kingdom of Denmark	denmark	DK	DNK	208	208	54	78	Europe	Northern Europe	DK	DK	DK	DNK	DNK	DNK	DNK	DNK	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen		1945	1945		EU						G20	Denmark	3	dk	390
@@ -75,7 +75,7 @@ Estonia	Republic of Estonia	estonia	EE	EST	233	233	63	58	Europe	Northern Europe	
 Eswatini	Kingdom of Eswatini	swaziland|eswatini	SZ	SWZ	748	748	209	197	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SWZ	AFR	Rest of Southern Africa	SSA												1968	1968		RoW							Other Africa	280	sz	572
 Ethiopia	Federal Democratic Republic of Ethiopia	ethiopia|abyssinia	ET	ETH	231	231	238	179	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ETH	AFR	Eastern Africa	SSA												1945	1945		RoW							Ethiopia	238	et	530
 Faeroe Islands	Faeroe Islands	faroe|faeroe	FO	FRO	234	234	64		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	FRO	WEU	Western Europe	EUR										Schengen					RoW									fo	
-Falkland Islands	Falkland Islands (Malvinas)	falkland|malvinas	FK	FLK	238	238	65		America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	FLK		Rest of South America	LAM															RoW							Other non-OECD Americas		fk	
+Falkland Islands	Falkland Islands (Malvinas)	falkland|malvinas	FK	FLK	238	238	65		America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	FLK	LAC	Rest of South America	LAM															RoW							Other non-OECD Americas		fk	
 Fiji	Republic of Fiji	fiji	FJ	FJI	242	242	66	22	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	FJI	PAS	Oceania	OAS												1970	1970		RoW							Other non-OECD Asia	832	fj	950
 Finland	Republic of Finland	finland	FI	FIN	246	246	67	79	Europe	Northern Europe	FI	FI	FI	FIN	FIN	FIN	FIN	FIN	WEU	Western Europe	EUR	1969	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen	1999	1955	1955		EU						G20	Finland	18	fi	375
 France	French Republic	^(?!.*\bdep).*france|french.?republic|\bgaul	FR	FRA	250	250	68	80	Europe	Western Europe	FR	FR	FR	FRA	FRA	FRA	FRA	FRA	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU					G7	G20	France	4	fr	220
@@ -131,7 +131,7 @@ Libya	State of Libya	libya	LY	LBY	434	434	124	147	Africa	Northern Africa	WW	WF	W
 Liechtenstein	Principality of Liechtenstein	liechtenstein	LI	LIE	438	438	125		Europe	Western Europe	WW	WE	WE	WWW	WWE	WWE	RoW	LIE	WEU	Western Europe	NEU									EEA	Schengen		1990	1990		RoW								70	li	223
 Lithuania	Republic of Lithuania	lithuania	LT	LTU	440	440	126	60	Europe	Northern Europe	LT	LT	LT	LTU	LTU	LTU	LTU	LTU	EEU	Central Europe	EUR	2018	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2015	1991	1991		EU						G20	Lithuania	84	lt	368
 Luxembourg	Grand Duchy of Luxembourg	^(?!.*belg).*luxem	LU	LUX	442	442	256	87	Europe	Western Europe	LU	LU	LU	LUX	LUX	LUX	LUX	LUX	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU						G20	Luxembourg	22	lu	212
-Macau	Macau SAR	.*maca(o|u)	MO	MAC	446	446	128		Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MAC		China region	CHA															RoW							Other non-OECD Asia		mo	
+Macau	Macau SAR	.*maca(o|u)	MO	MAC	446	446	128		Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MAC	PAS	China region	CHA															RoW							Other non-OECD Asia		mo	
 North Macedonia	Republic of North Macedonia	macedonia|^f\.?y\.?r\.?o\.?m\.?$	MK	MKD	807	807	154	49	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MKD	EEU	Central Europe	NEU												1993	1993		RoW							Republic of North Macedonia	66	mk	343
 Madagascar	Republic of Madagascar	madagascar|malagasy	MG	MDG	450	450	129	181	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MDG	AFR	Eastern Africa	SSA												1960	1960		RoW							Other Africa	252	mg	580
 Malawi	Republic of Malawi	malawi|nyasa	MW	MWI	454	454	130	182	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MWI	AFR	Rest of Southern Africa	SSA												1964	1964		RoW							Other Africa	253	mw	553
@@ -139,23 +139,23 @@ Malaysia	Malaysia	malaysia	MY	MYS	458	458	131	13	Asia	South-eastern Asia	WW	WA	W
 Maldives	Republic of Maldives	maldive	MV	MDV	462	462	132	14	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MDV	SAS	Rest of South Asia	OAS												1965	1965		RoW							Other non-OECD Asia	655	mv	781
 Mali	Republic of Mali	\bmali\b	ML	MLI	466	466	133	211	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MLI	AFR	Western Africa	SSA												1960	1960		RoW							Other Africa	255	ml	432
 Malta	Republic of Malta	\bmalta	MT	MLT	470	470	134	88	Europe	Southern Europe	MT	MT	MT	MLT	MLT	MLT	MLT	MLT	WEU	Western Europe	EUR		EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2008	1964	1964		EU						G20	Malta	45	mt	338
-Marshall Islands	Republic of the Marshall Islands	marshall	MH	MHL	584	584	127	24	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	MHL		Oceania	OAS												1991	1991		RoW							Other non-OECD Asia	859	mh	983
+Marshall Islands	Republic of the Marshall Islands	marshall	MH	MHL	584	584	127	24	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	MHL	PAS	Oceania	OAS												1991	1991		RoW							Other non-OECD Asia	859	mh	983
 Martinique	Martinique	martinique	MQ	MTQ	474	474	135		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MTQ	LAC	Central America	LAM															RoW							Other non-OECD Americas		mq	
 Mauritania	Islamic Republic of Mauritania	mauritania	MR	MRT	478	478	136	212	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MRT	AFR	Western Africa	SSA												1961	1961		RoW							Other Africa	256	mr	435
 Mauritius	Republic of Mauritius	mauritius	MU	MUS	480	480	137	183	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MUS	AFR	Eastern Africa	SSA												1968	1968		RoW							Mauritius	257	mu	590
-Mayotte	Mayotte	mayotte	YT	MYT	175	175	270		Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MYT			SSA															RoW							Other Africa		yt	
+Mayotte	Mayotte	mayotte	YT	MYT	175	175	270		Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MYT	AFR		SSA															RoW							Other Africa		yt	
 Mexico	United Mexican States	^(?!.*new).*mexi(?!.*city)	MX	MEX	484	484	138	130	America	Central America	MX	MX	MX	MEX	MEX	MEX	MEX	MEX	LAC	Mexico	LAM	1994											1945	1945		BX		APEC				G20	Mexico	358	mx	70
-Micronesia, Fed. Sts.	Federated States of Micronesia	micronesia	FM	FSM	583	583	145	25	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	FSM		Oceania	OAS												1991	1991		RoW							Other non-OECD Asia	860	fm	987
+Micronesia, Fed. Sts.	Federated States of Micronesia	micronesia	FM	FSM	583	583	145	25	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	FSM	PAS	Oceania	OAS												1991	1991		RoW							Other non-OECD Asia	860	fm	987
 Moldova	Republic of Moldova	moldov|b(a|e)ssarabia	MD	MDA	498	498	146	61	Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MDA	FSU	Ukraine region	REF												1992	1992		RoW				CIS			Republic of Moldova	93	md	359
 Monaco	Principality of Monaco	monaco	MC	MCO	492	492	140	367	Europe	Western Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MCO	WEU	Western Europe	NEU												1993	1993		RoW									mc	221
 Mongolia	Mongolia	mongolia	MN	MNG	496	496	141	38	Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MNG	CPA	China region	OAS												1961	1961		RoW							Mongolia	753	mn	712
-Montenegro	Montenegro	^(?!.*serbia).*montenegro	ME	MNE	499	499	273	50	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MNE		Central Europe	NEU												2006	2006		RoW							Montenegro	65	me	341
-Montserrat	Montserrat	montserrat	MS	MSR	500	500	142		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MSR		Central America	LAM															RoW							Other non-OECD Americas	385	ms	
+Montenegro	Montenegro	^(?!.*serbia).*montenegro	ME	MNE	499	499	273	50	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	MNE	EEU	Central Europe	NEU												2006	2006		RoW							Montenegro	65	me	341
+Montserrat	Montserrat	montserrat	MS	MSR	500	500	142		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MSR	LAC	Central America	LAM															RoW							Other non-OECD Americas	385	ms	
 Morocco	Kingdom of Morocco	morocco|\bmaroc	MA	MAR	504	504	143	148	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MAR	MEA	Northern Africa	MEA												1956	1956		RoW							Morocco	136	ma	600
 Mozambique	Republic of Mozambique	mozambique	MZ	MOZ	508	508	144	184	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	MOZ	AFR	Rest of Southern Africa	SSA												1975	1975		RoW							Mozambique	259	mz	541
 Myanmar	Republic of the Union of Myanmar	myanmar|burma	MM	MMR	104	104	28	15	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	MMR	PAS	Southeastern Asia	OAS												1948	1948		RoW							Myanmar	635	mm	775
 Namibia	Republic of Namibia	namibia	NA	NAM	516	516	147	195	Africa	Southern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NAM	AFR	Rest of Southern Africa	SSA												1990	1990		RoW							Namibia	275	na	565
-Nauru	Republic of Nauru	nauru	NR	NRU	520	520	148	369	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	NRU		Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	845	nr	971
+Nauru	Republic of Nauru	nauru	NR	NRU	520	520	148	369	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	NRU	PAS	Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	845	nr	971
 Nepal	Federal Democratic Republic of Nepal	nepal	NP	NPL	524	524	149	164	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	NPL	SAS	Rest of South Asia	OAS												1955	1955		RoW							Nepal	660	np	790
 Netherlands	Kingdom of the Netherlands	^(?!.*\bant)(?!.*\bcarib).*netherlands	NL	NLD	528	528	150	89	Europe	Western Europe	NL	NL	NL	NLD	NLD	NLD	NLD	NLD	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1945	1945		EU						G20	Netherlands	7	nl	210
 Netherlands Antilles	Netherlands Antilles	^(?=.*\bant).*(neth.*|dutch)	AN	ANT	530		151		America		WW	WL	WL	WWW	WWL	WWL	RoW	ANT	LAC	Central America															2010	RoW										
@@ -164,21 +164,21 @@ New Zealand	New Zealand	(new|n).*zealand	NZ	NZL	554	554	156	72	Oceania	Australia
 Nicaragua	Republic of Nicaragua	nicaragua	NI	NIC	558	558	157	131	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	NIC	LAC	Central America	LAM												1945	1945		RoW							Nicaragua	364	ni	93
 Niger	Republic of Niger	\bniger(?!ia)	NE	NER	562	562	158	213	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NER	AFR	Western Africa	SSA												1960	1960		RoW							Niger	260	ne	436
 Nigeria	Federal Republic of Nigeria	nigeria	NG	NGA	566	566	159	214	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	NGA	AFR	Western Africa	SSA												1960	1960		RoW							Nigeria	261	ng	475
-Niue	Niue	niue	NU	NIU	570	570	160	374	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	NIU		Oceania	OAS															RoW							Other non-OECD Asia	856	nu	
-Norfolk Island	Norfolk Island	norfolk.*is	NF	NFK	574	574	161		Oceania	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW	NFK			OAS															RoW							Other non-OECD Asia		nf	
+Niue	Niue	niue	NU	NIU	570	570	160	374	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	NIU	PAS	Oceania	OAS															RoW							Other non-OECD Asia	856	nu	
+Norfolk Island	Norfolk Island	norfolk.*is	NF	NFK	574	574	161		Oceania	Australia and New Zealand	WW	WA	WA	WWW	WWA	WWA	RoW	NFK	PAS		OAS															RoW							Other non-OECD Asia		nf	
 North Korea	Democratic People's Republic of Korea	^(?=.*dem).*\bkorea|^(?=.*peo).*\bkorea|^(?=.*nor).*\bkorea|\bd\.?p\.?r\.|.*dpr.*|^n.*korea	KP	PRK	408	408	116	7	Asia	Eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PRK	CPA	Korea region	OAS												1991	1991		RoW							Democratic People's Republic of Korea	740	kp	731
-Northern Mariana Islands	Northern Mariana Islands	mariana	MP	MNP	580	580	163	376	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	MNP		Oceania	OAS															RoW							Other non-OECD Asia		mp	
+Northern Mariana Islands	Northern Mariana Islands	mariana	MP	MNP	580	580	163	376	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	MNP	PAS	Oceania	OAS															RoW							Other non-OECD Asia		mp	
 Norway	Kingdom of Norway	norway	NO	NOR	578	578	162	90	Europe	Northern Europe	NO	NO	NO	NOR	NOR	NOR	RoW	NOR	WEU	Western Europe	NEU	1961								EEA	Schengen		1945	1945		HI							Norway	8	no	385
 Oman	Sultanate of Oman	\boman|trucial	OM	OMN	512	512	221	150	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	OMN	MEA	Middle East	MEA												1971	1971		RoW							Oman		om	698
 Pakistan	Islamic Republic of Pakistan	^(?!.*east).*paki?stan	PK	PAK	586	586	165	165	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PAK	SAS	Rest of South Asia	OAS												1947	1947		RoW							Pakistan	665	pk	770
-Palau	Republic of Palau	palau	PW	PLW	585	585	180	380	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	PLW		Oceania	OAS												1994	1994		RoW							Other non-OECD Asia	861	pw	986
-Palestine	State of Palestine	palestin|\bgaza|west.?bank	PS	PSE	275	275	299	149	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	PSE			MEA															RoW							Other non-OECD Asia	550	ps	
+Palau	Republic of Palau	palau	PW	PLW	585	585	180	380	Oceania	Micronesia	WW	WA	WA	WWW	WWA	WWA	RoW	PLW	PAS	Oceania	OAS												1994	1994		RoW							Other non-OECD Asia	861	pw	986
+Palestine	State of Palestine	palestin|\bgaza|west.?bank	PS	PSE	275	275	299	149	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	PSE	MEA		MEA															RoW							Other non-OECD Asia	550	ps	
 Panama	Republic of Panama	panama	PA	PAN	591	591	166	132	America	Central America	WW	WL	WL	WWW	WWL	WWL	RoW	PAN	LAC	Central America	LAM												1945	1945		RoW							Panama	366	pa	95
 Papua New Guinea	Independent State of Papua New Guinea	\bp.*\bn.*\bguin.*|^p\.?n\.?g\.?$|new.?guinea	PG	PNG	598	598	168	26	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	PNG	PAS	Indonesia region	OAS												1975	1975		RoW		APEC					Other non-OECD Asia	862	pg	910
 Paraguay	Republic of Paraguay	paraguay	PY	PRY	600	600	169	136	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	PRY	LAC	Rest of South America	LAM												1945	1945		RoW							Paraguay	451	py	150
 Peru	Republic of Peru	peru	PE	PER	604	604	170	123	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	PER	LAC	Rest of South America	LAM												1945	1945		RoW		APEC					Peru	454	pe	135
 Philippines	Republic of the Philippines	philippines	PH	PHL	608	608	171	16	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	PHL	PAS	Southeastern Asia	OAS												1945	1945		RoW		APEC					Philippines	755	ph	840
-Pitcairn	Pitcairn	pitcairn	PN	PCN	612	612	172		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	PCN		Oceania	OAS															RoW							Other non-OECD Asia		pn	
+Pitcairn	Pitcairn	pitcairn	PN	PCN	612	612	172		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	PCN	PAS	Oceania	OAS															RoW							Other non-OECD Asia		pn	
 Poland	Republic of Poland	poland	PL	POL	616	616	173	51	Europe	Eastern Europe	PL	PL	PL	POL	POL	POL	POL	POL	EEU	Central Europe	EUR	1996	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen		1945	1945		EU						G20	Poland	76	pl	290
 Portugal	Portuguese Republic	portugal|portuguese	PT	PRT	620	620	174	91	Europe	Southern Europe	PT	PT	PT	PRT	PRT	PRT	PRT	PRT	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU						G20	Portugal	9	pt	235
 Puerto Rico	Puerto Rico	puerto.?rico	PR	PRI	630	630	177	385	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW		NAM	Central America	LAM															RoW							Other non-OECD Americas		pr	
@@ -189,15 +189,15 @@ Russia	Russian Federation	\brussia	RU	RUS	643	643	185	62	Europe	Eastern Europe	R
 Rwanda	Republic of Rwanda	rwanda	RW	RWA	646	646	184	185	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	RWA	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	266	rw	517
 Saint-Martin	Saint-Martin (French part)	^(?!.*maarten)(?!.*saba)(?!.*dutch).*martin\b	MF	MAF	663	663	281		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	MAF			LAM															RoW							Other non-OECD Americas			
 Samoa	Independent State of Samoa	^(?!.*amer.*)samoa|(\bindep.*samoa)|^west.*samoa	WS	WSM	882	882	244	27	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	WSM	PAS	Oceania	OAS												1976	1976		RoW							Other non-OECD Asia		ws	990
-San Marino	Republic of San Marino	san.?marino	SM	SMR	674	674	192	396	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SMR		Western Europe	NEU												1992	1992		RoW									sm	331
+San Marino	Republic of San Marino	san.?marino	SM	SMR	674	674	192	396	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SMR	WEU	Western Europe	NEU												1992	1992		RoW									sm	331
 Sao Tome and Principe	Democratic Republic of São Tomé and Príncipe	tome|tomé	ST	STP	678	678	193	215	Africa	Middle Africa	WW	WF	WF	WWW	WWF	WWF	RoW	STP	AFR	Western Africa	SSA												1975	1975		RoW							Other Africa	268	st	403
 Saudi Arabia	Kingdom of Saudi Arabia	\bsa\w*.?arabia	SA	SAU	682	682	194	152	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	SAU	MEA	Middle East	MEA												1945	1945		RoW						G20	Saudi Arabia	566	sa	670
 Senegal	Republic of Senegal	senegal	SN	SEN	686	686	195	216	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SEN	AFR	Western Africa	SSA												1960	1960		RoW							Senegal	269	sn	433
-Serbia	Republic of Serbia	^(?!.*monte).*serbia.*	RS	SRB	688	688	272	53	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SRB		Central Europe	NEU												2000	2000		RoW							Serbia	63	rs	340
+Serbia	Republic of Serbia	^(?!.*monte).*serbia.*	RS	SRB	688	688	272	53	Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SRB	EEU	Central Europe	NEU												2000	2000		RoW							Serbia	63	rs	340
 Seychelles	Republic of Seychelles	seychell	SC	SYC	690	690	196	186	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SYC	AFR	Eastern Africa	SSA												1976	1976		RoW							Other Africa		sc	591
 Sierra Leone	Republic of Sierra Leone	sierra	SL	SLE	694	694	197	217	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SLE	AFR	Western Africa	SSA												1961	1961		RoW							Other Africa	272	sl	451
 Singapore	Republic of Singapore	singapore	SG	SGP	702	702	200	69	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	SGP	PAS	Southeastern Asia	OAS												1965	1965		RoW		APEC					Singapore		sg	830
-Sint Maarten	Sint Maarten (Dutch part)	^(?!.*martin)(?!.*saba).*maarten|dutch.*martin|martin.*dutch	SX	SXM	534	534	280		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW				LAM															RoW							Other non-OECD Americas		sx	
+Sint Maarten	Sint Maarten (Dutch part)	^(?!.*martin)(?!.*saba).*maarten|dutch.*martin|martin.*dutch	SX	SXM	534	534	280		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW		LAC		LAM															RoW							Other non-OECD Americas		sx	
 Slovakia	Slovak Republic	^(?!.*cze).*slovak	SK	SVK	703	703	199	54	Europe	Eastern Europe	SK	SK	SK	SVK	SVK	SVK	SVK	SVK	EEU	Central Europe	EUR	2000	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2009	1993	1993		EU						G20	Slovak Republic	69	sk	317
 Slovenia	Republic of Slovenia	slovenia	SI	SVN	705	705	198	55	Europe	Southern Europe	SI	SI	SI	SVN	SVN	SVN	SVN	SVN	EEU	Central Europe	EUR	2010	EU	EU28	EU27	EU27_2007	EU25			EEA	Schengen	2007	1992	1992		EU						G20	Slovenia	61	si	349
 Solomon Islands	Solomon Islands	solomon	SB	SLB	90	90	25	28	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	SLB	PAS	Oceania	OAS												1978	1978		RoW							Other non-OECD Asia	866	sb	940
@@ -205,7 +205,7 @@ Somalia	Federal Republic of Somalia	somali	SO	SOM	706	706	201	187	Africa	Eastern
 South Africa	Republic of South Africa	\bs(\.|outh)(?!.*sahar).*africa|^r\.?s\.?a\.?$	ZA	ZAF	710	710	202	196	Africa	Southern Africa	ZA	ZA	ZA	ZAF	ZAF	ZAF	RoW	ZAF	AFR	South Africa	SSA												1945	1945		BX			BASIC			G20	South Africa	218	za	560
 South Georgia and South Sandwich Is.	South Georgia and The South Sandwich Islands	south.?georgia|sandwich	GS	SGS	239	239	271		Antarctica	South America	WW	WA	WA	WWW	WWA	WWA	RoW				LAM															RoW							Other non-OECD Asia		gs	
 South Korea	Republic of Korea	^(?!.*dem)(?!.*peo)(?!.*nor)(?!.*n)(?!.*dpr)(?!d\.p\.r).*\bkorea|\br\.?o\.?k\b	KR	KOR	410	410	117	68	Asia	Eastern Asia	KR	KR	KR	KOR	KOR	KOR	KOR	KOR	PAS	Korea region	OAS	1996											1991	1991		HI		APEC				G20	Korea	742	kr	732
-South Sudan	Republic of South Sudan	\bs\w*.?sudan	SS	SSD	728	728	277	435	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SDS			SSA												2011	2011		RoW							South Sudan	279	ss	626
+South Sudan	Republic of South Sudan	\bs\w*.?sudan	SS	SSD	728	728	277	435	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SDS	MEA		SSA												2011	2011		RoW							South Sudan	279	ss	626
 Soviet Union (former)	Union of Soviet Socialist Republics (former)	USSR|soviet	SU	SUN	810	810			Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	USR																	1992	RoW							Former Soviet Union (if no detail)		su	
 Spain	Kingdom of Spain	spain	ES	ESP	724	724	203	92	Europe	Southern Europe	ES	ES	ES	ESP	ESP	ESP	ESP	ESP	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15	EU12	EEA	Schengen	1999	1955	1955		EU						G20	Spain	50	es	230
 Sri Lanka	Democratic Socialist Republic of Sri Lanka	sri.?lanka|ceylon	LK	LKA	144	144	38	17	Asia	Southern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	LKA	SAS	Rest of South Asia	OAS												1955	1955		RoW							Sri Lanka	640	lk	780
@@ -213,11 +213,11 @@ St. Barths	Territorial collectivity of Saint-Barthélemy	barth|barts	BL	BLM	652	
 St. Helena	Saint Helena, Ascension and Tristan da Cunha	helena	SH	SHN	654	654	187		Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SHN	AFR	Western Africa	SSA															RoW							Other Africa	276	sh	
 St. Kitts and Nevis	Saint Kitts and Nevis	kitts|\bnevis	KN	KNA	659	659	188	393	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	KNA	LAC	Central America	LAM												1983	1983		RoW							Other non-OECD Americas		kn	60
 St. Lucia	Saint Lucia	\blucia	LC	LCA	662	662	189	116	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	LCA	LAC	Central America	LAM												1979	1979		RoW							Other non-OECD Americas	383	lc	56
-St. Pierre and Miquelon	Saint Pierre and Miquelon	miquelon	PM	SPM	666	666	190		America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	SPM		USA	CAZ															RoW							Other non-OECD Americas		pm	
+St. Pierre and Miquelon	Saint Pierre and Miquelon	miquelon	PM	SPM	666	666	190		America	Northern America	WW	WL	WL	WWW	WWL	WWL	RoW	SPM	NAM	USA	CAZ															RoW							Other non-OECD Americas		pm	
 St. Vincent and the Grenadines	Saint Vincent and the Grenadines	vincent	VC	VCT	670	670	191	117	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	VCT	LAC	Central America	LAM												1980	1980		RoW							Other non-OECD Americas	384	vc	57
 Sudan	Republic of the Sudan	^(?!.*\bs(?!u)).*sudan	SD	SDN	729	729		522	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	SUD	MEA	Eastern Africa	MEA												1956	1956		RoW							Sudan	278	sd	625
 Suriname	Republic of Suriname	surinam|dutch.?guiana	SR	SUR	740	740	207	118	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	SUR	LAC	Rest of South America	LAM												1975	1975		RoW							Suriname	457	sr	115
-Svalbard and Jan Mayen Islands	Svalbard and Jan Mayen Islands	^(?!norway).*svalbard	SJ	SJM	744	744	260		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SJM			NEU															RoW										
+Svalbard and Jan Mayen Islands	Svalbard and Jan Mayen Islands	^(?!norway).*svalbard	SJ	SJM	744	744	260		Europe	Northern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	SJM	WEU		NEU															RoW										
 Sweden	Kingdom of Sweden	swedish|sweden(?!.*except)	SE	SWE	752	752	210	93	Europe	Northern Europe	SE	SE	SE	SWE	SWE	SWE	SWE	SWE	WEU	Western Europe	EUR	1961	EU	EU28	EU27	EU27_2007	EU25	EU15		EEA	Schengen		1946	1946		EU						G20	Sweden	10	se	380
 Switzerland	Swiss Confederation	switz|swiss	CH	CHE	756	756	211	94	Europe	Western Europe	CH	CH	CH	CHE	CHE	CHE	RoW	CHE	WEU	Western Europe	NEU	1961									Schengen		2002	2002		HI							Switzerland	11	ch	225
 Syria	Syrian Arab Republic	syria	SY	SYR	760	760	212	153	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	SYR	MEA	Middle East	MEA												1945	1945		RoW							Syrian Arab Republic	573	sy	652
@@ -226,16 +226,16 @@ Tajikistan	Republic of Tajikistan	tajik	TJ	TJK	762	762	208	39	Asia	Central Asia	
 Tanganjika	Republic of Tanganyika	tanganjika|tanganyika		EAT					Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW																		1964	RoW							Other Africa			
 Tanzania	United Republic of Tanzania	tanzania(?!: zan.*)	TZ	TZA	834	834	215	189	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TZA	AFR	Rest of Southern Africa	SSA												1961	1961		RoW							United Republic of Tanzania	282	tz	510
 Thailand	Kingdom of Thailand	thailand|\bsiam	TH	THA	764	764	216	18	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	THA	PAS	Southeastern Asia	OAS												1946	1946		RoW		APEC					Thailand	764	th	800
-Timor-Leste	Democratic Republic of Timor-Leste	^(?=.*leste).*timor|^(?=.*east).*timor	TL	TLS	626	626	176	19	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TLS		Indonesia region	OAS												2002	2002		RoW							Other non-OECD Asia	765	tl	860
+Timor-Leste	Democratic Republic of Timor-Leste	^(?=.*leste).*timor|^(?=.*east).*timor	TL	TLS	626	626	176	19	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TLS	PAS	Indonesia region	OAS												2002	2002		RoW							Other non-OECD Asia	765	tl	860
 Togo	Togolese Republic	togo	TG	TGO	768	768	217	218	Africa	Western Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TGO	AFR	Western Africa	SSA												1960	1960		RoW							Togo	283	tg	461
-Tokelau	Tokelau	tokelau	TK	TKL	772	772	218	413	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TKL		Oceania	OAS															RoW							Other non-OECD Asia	868	tk	
+Tokelau	Tokelau	tokelau	TK	TKL	772	772	218	413	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TKL	PAS	Oceania	OAS															RoW							Other non-OECD Asia	868	tk	
 Tonga	Kingdom of Tonga	tonga	TO	TON	776	776	219	29	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TON	PAS	Oceania	OAS												1999	1999		RoW							Other non-OECD Asia	870	to	972
 Trinidad and Tobago	Republic of Trinidad and Tobago	trinidad|tobago	TT	TTO	780	780	220	119	America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TTO	LAC	Central America	LAM												1962	1962		RoW							Trinidad and Tobago		tt	52
 Tunisia	Republic of Tunisia	tunisia	TN	TUN	788	788	222	154	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	TUN	MEA	Northern Africa	MEA												1956	1956		RoW							Tunisia	139	tn	616
 Türkiye	Republic of Türkiye	t[ü|u]rk[i|e]y	TR	TUR	792	792	223	155	Asia	Western Asia	TR	TR	TR	TUR	TUR	TUR	TUR	TUR	WEU	Turkey	NEU	1961											1945	1945		BX						G20	Türkiye	55	tr	640
 Turkmenistan	Turkmenistan	turk-?men	TM	TKM	795	795	213	40	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	TKM	FSU	Central Asia	REF												1992	1992		RoW							Turkmenistan	616	tm	701
-Turks and Caicos Islands	Turks and Caicos Islands	turks	TC	TCA	796	796	224		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TCA		Central America	LAM															RoW							Other non-OECD Americas		tc	
-Tuvalu	Tuvalu	tuvalu	TV	TUV	798	798	227	416	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TUV		Oceania	OAS												2000	2000		RoW							Other non-OECD Asia	872	tv	973
+Turks and Caicos Islands	Turks and Caicos Islands	turks	TC	TCA	796	796	224		America	Caribbean	WW	WL	WL	WWW	WWL	WWL	RoW	TCA	LAC	Central America	LAM															RoW							Other non-OECD Americas		tc	
+Tuvalu	Tuvalu	tuvalu	TV	TUV	798	798	227	416	Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	TUV	PAS	Oceania	OAS												2000	2000		RoW							Other non-OECD Asia	872	tv	973
 Uganda	Republic of Uganda	uganda	UG	UGA	800	800	226	190	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	UGA	AFR	Eastern Africa	SSA												1962	1962		RoW							Other Africa	285	ug	500
 Ukraine	Ukraine	ukrain	UA	UKR	804	804	230	63	Europe	Eastern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	UKR	FSU	Ukraine region	REF												1945	1945		RoW							Ukraine	85	ua	369
 United Arab Emirates	United Arab Emirates	emirates|^u\.?a\.?e\.?$|united.?arab.?em	AE	ARE	784	784	225	156	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	ARE	MEA	Middle East	MEA												1971	1971		RoW							United Arab Emirates	576	ae	696
@@ -246,11 +246,11 @@ United States Virgin Islands	Virgin Islands of the United States	^(?=.*\bu\.?\s?
 Uruguay	Oriental Republic of Uruguay	uruguay	UY	URY	858	858	234	99	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	URY	LAC	Rest of South America	LAM												1945	1945		RoW							Uruguay		uy	165
 Uzbekistan	Republic of Uzbekistan	uzbek	UZ	UZB	860	860	235	41	Asia	Central Asia	WW	WA	WA	WWW	WWA	WWA	RoW	UZB	FSU	Central Asia	REF												1992	1992		RoW				CIS			Uzbekistan	617	uz	704
 Vanuatu	Republic of Vanuatu	vanuatu|new.?hebrides	VU	VUT	548	548	155	30	Oceania	Melanesia	WW	WA	WA	WWW	WWA	WWA	RoW	VUT	PAS	Oceania	OAS												1981	1981		RoW							Other non-OECD Asia	854	vu	935
-Vatican	Vatican City State	holy.?see|vatican|papal.?st	VA	VAT	336	336	94		Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	VAT		Western Europe	NEU															RoW									va	
+Vatican	Vatican City State	holy.?see|vatican|papal.?st	VA	VAT	336	336	94		Europe	Southern Europe	WW	WE	WE	WWW	WWE	WWE	RoW	VAT	WEU	Western Europe	NEU															RoW									va	
 Venezuela	Bolivarian Republic of Venezuela	venezuela	VE	VEN	862	862	236	133	America	South America	WW	WL	WL	WWW	WWL	WWL	RoW	VEN	LAC	Rest of South America	LAM												1945	1945		RoW							Bolivarian Republic of Venezuela	463	ve	101
 Vietnam	Socialist Republic of Vietnam	^((?!n|s|.*republic)|(?=.*socialist)).*viet.?nam(?! *,? *n| *,? *s)	VN	VNM	704	704	237	20	Asia	South-eastern Asia	WW	WA	WA	WWW	WWA	WWA	RoW	VNM	CPA	Southeastern Asia	OAS												1977	1977		RoW		APEC					Viet Nam	769	vn	817
-Wallis and Futuna Islands	Wallis and Futuna Islands	futuna|wallis	WF	WLF	876	876	243		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	WLF		Oceania	OAS															RoW							Other non-OECD Asia	876	wf	
-Western Sahara	Western Sahara	\bw.*sahara	EH	ESH	732	732	205	199	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ESH		Northern Africa	MEA															RoW							Other Africa		eh	
+Wallis and Futuna Islands	Wallis and Futuna Islands	futuna|wallis	WF	WLF	876	876	243		Oceania	Polynesia	WW	WA	WA	WWW	WWA	WWA	RoW	WLF	PAS	Oceania	OAS															RoW							Other non-OECD Asia	876	wf	
+Western Sahara	Western Sahara	\bw.*sahara	EH	ESH	732	732	205	199	Africa	Northern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ESH	MEA	Northern Africa	MEA															RoW							Other Africa		eh	
 Yemen	Republic of Yemen	yemen	YE	YEM	887	887	249	157	Asia	Western Asia	WW	WM	WM	WWW	WWM	WWM	RoW	YEM	MEA	Middle East	MEA												1947	1947		RoW							Yemen	580	ye	680
 Zambia	Republic of Zambia	zambia|northern.?rhodesia	ZM	ZMB	894	894	251	191	Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW	ZMB	AFR	Rest of Southern Africa	SSA												1964	1964		RoW							Zambia	288	zm	551
 Zanzibar	Zanzibar	zanz|.*tanzania:?zanzibar		EAZ					Africa	Eastern Africa	WW	WF	WF	WWW	WWF	WWF	RoW																		1964	RoW							Other Africa			


### PR DESCRIPTION
- Filled in MESSAGE 11-region classification for 36 countries where it was missing
- Data from official data source: [IIASA-MESSAGE](https://docs.messageix.org/projects/models/en/latest/pkg-data/node.html#region-aggregation-r11)
- Abbreviation `LAC ` is maintained for Latin America and the Caribbean and not changed to `LAM` as used by IIASA for compatibility