### PR TITLE
Move project metadata to pyproject.toml

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -10,25 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-        # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
           pip install build twine
       - name: Build and check packages
         run: |

--- a/.github/workflows/puplish_test_pypi.yml
+++ b/.github/workflows/puplish_test_pypi.yml
@@ -10,23 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
           pip install build twine
       - name: Build and check packages
         run: |

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Cache conda
       uses: actions/cache@v2
@@ -70,18 +70,19 @@ jobs:
 
     steps:
        - name: Check out repository code
-         uses: actions/checkout@v2
+         uses: actions/checkout@v3
 
        - name: Setup Python
-         uses: actions/setup-python@v2
+         uses: actions/setup-python@v4
          with:
             python-version: ${{matrix.python-version}}
+            cache: 'pip'
+            cache-dependency-path: pyproject.toml
 
-       - name: Run tests
+       - name: Install and run tests
          run: |
-            pip install . -U
-            pip install pytest
-            pip install -e .
+            python -m pip install --upgrade pip
+            pip install -e .[dev]
             pytest -vv
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,13 +75,13 @@ The following commands can be used to automatically apply the
 [isort](https://github.com/pycqa/isort/) formatting.
 
 ``` bash
-isort --project country_converter --profile black .
+isort .
 black .
 ```
 
 If you are using Conda you can build a development environment from
 environment.yml which includes all packages necessary for development
-and running. For virtual environments use the requirements.txt file. The
+and running. For virtual environments use `pip install -e .[dev]`. The
 file format_and_test.sh can be used in Linux environments to format the
 code according to the [black](https://github.com/psf/black/) /
 [isort](https://github.com/pycqa/isort/) format and run all tests.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include README.md
-include requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,69 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools >=61"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "country_converter"
+authors = [
+    {name = "Konstantin Stadler", email = "konstantin.stadler@ntnu.no"},
+]
+description = "The country converter (coco) - a Python package for converting country names between different classifications schemes"
+readme = "README.md"
+keywords = ["country", "ISO 3166"]
+dynamic = ["version"]
+license = {text = "GNU General Public License v3 (GPLv3)"}
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Utilities",
+]
+requires-python = ">=3.7"
+dependencies = [
+  "pandas >=1.0",
+]
+
+[project.optional-dependencies]
+dev = ["country_converter[lint,test]"]
+lint = [
+  "black >=22.3.0",
+  "isort >=5.5.2",
+]
+test = [
+  "coveralls",
+  "pytest >=5.4.0",
+  "pytest-black",
+  "pytest-cov >=2.7.0",
+  "pytest-datadir",
+  "pytest-mypy",
+]
+
+[project.scripts]
+coco = "country_converter.country_converter:main"
+
+[project.urls]
+Repository = "https://github.com/konstantinstadler/country_converter"
+
+[tool.setuptools]
+packages = ["country_converter"]
+
+[tool.setuptools.package-data]
+country_converter = ["country_data.tsv"]
+
+[tool.setuptools.dynamic]
+version = {attr = "country_converter.version.__version__"}
 
 [tool.isort]
 profile = "black"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-pandas >= 1.0
-pytest >= 5.4.0
-pytest-cov >= 2.7.0
-isort >= 5.5.2
-black >= 22.3.0
-coveralls
-pytest-black

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,4 @@
 from setuptools import setup
 
-exec(open("country_converter/version.py").read())
-
-setup(
-    name="country_converter",
-    description=(
-        "The country converter (coco) - "
-        "a Python package for converting country names "
-        "between different classifications schemes."
-    ),
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
-    license="GNU General Public License v3 (GPLv3)",
-    url="https://github.com/konstantinstadler/country_converter",
-    author="Konstantin Stadler",
-    author_email="konstantin.stadler@ntnu.no",
-    version=__version__,  # noqa
-    packages=["country_converter"],
-    package_data={"country_converter": ["country_data.tsv", "../LICENSE"]},
-    entry_points={
-        "console_scripts": ["coco = country_converter.country_converter:main"]
-    },
-    install_requires=["pandas >= 1.0"],
-    classifiers=[
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3 :: Only",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Development Status :: 4 - Beta",
-        "Environment :: Console",
-        "Intended Audience :: End Users/Desktop",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX",
-        "Programming Language :: Python",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Utilities",
-    ],
-)
+# See pyproject.toml for projectmetadata
+setup(name="country_converter")


### PR DESCRIPTION
Move project metadata from `setup.py` to `pyproject.toml` as described by [PEP 621](https://peps.python.org/pep-0621/) and supported by [setuptools >= 61](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).

Most of this should be a 1:1 conversion, with these changes to the metadata:

- Add some keywords
- Remove `LICENSE` from `package_data` since this file already installed to `site-packages/country_converter-0.8.1.dev0.dist-info/` along with standard metadata
- Classifiers are sorted; add `Programming Language :: Python :: 3.11`

Other changes:
- Remove `requirements.txt` as these have been moved to `pyproject.toml`. For instance, `project.optional-dependencies` lists a few "extras" that can be installed via e.g. `pip install -e .[dev]` to also install development dependencies. I've split `lint` and `test` names, but they could simply be combined to just `dev` if desired.
- Remove `MANIFEST.in` since `README.md` is normally implied to be included for `sdist`
- Upgrade CI `actions/checkout` and `actions/setup-python` to their latest stable versions
- Remove "Cache pip" from publish jobs, since the build requirements are trivial
